### PR TITLE
feat: show available commands in boxes list output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,11 @@ import { TerminatingWarning } from "./lib/errors";
 import packageJson from "../package.json";
 import { BoxState } from "./box";
 import { assertConfirmation, execCommand } from "./lib/cli-helpers";
-import { BoxesConfiguration, getConfiguration } from "./lib/configuration";
+import {
+  BoxesConfiguration,
+  getConfiguration,
+  getCommandsForBox,
+} from "./lib/configuration";
 import { importBox } from "./commands/import";
 
 const ERROR_CODE_WARNING = 1;
@@ -45,6 +49,14 @@ const cli = async (program: Command, configuration: BoxesConfiguration) => {
         }
         if (box.hasArchivedVolumes) {
           theme.printBoxDetail("Archived Volumes", "true");
+        }
+        const commands = getCommandsForBox(configuration, box.boxId);
+        const commandNames = Object.keys(commands);
+        if (commandNames.length > 0) {
+          theme.printBoxDetail("Commands", "");
+          for (const name of commandNames) {
+            theme.printCommandDetail(name, commands[name].description);
+          }
         }
       });
     });

--- a/src/lib/configuration.ts
+++ b/src/lib/configuration.ts
@@ -17,6 +17,7 @@ export interface CommandConfiguration {
   command: string;
   copyCommand?: string;
   parameters?: Record<string, string>;
+  description?: string;
 }
 
 export interface AwsConfiguration {
@@ -77,5 +78,15 @@ export async function getConfiguration(): Promise<BoxesConfiguration> {
     commands: json?.commands,
     archiveVolumesOnStop: json?.archiveVolumesOnStop,
     debugEnable: json?.debugEnable,
+  };
+}
+
+export function getCommandsForBox(
+  config: BoxesConfiguration,
+  boxId: string,
+): Record<string, CommandConfiguration> {
+  return {
+    ...config.commands,
+    ...config.boxes?.[boxId]?.commands,
   };
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -34,6 +34,11 @@ function printBoxDetail(name: string, value: string) {
   console.log(`  ${colors.white(name)}: ${colors.white(value)}`);
 }
 
+function printCommandDetail(name: string, description?: string) {
+  const desc = description ? ` - ${description}` : "";
+  console.log(`    ${colors.cyan(name)}${colors.gray(desc)}`);
+}
+
 function printWarning(message: string) {
   console.log(colors.yellow(message));
 }
@@ -47,6 +52,7 @@ export default {
   state,
   printBoxHeading,
   printBoxDetail,
+  printCommandDetail,
   printWarning,
   printError,
 };


### PR DESCRIPTION
## Summary
- Add `description` field to command configuration
- Display available commands under each box in `boxes list` output
- Merge global + per-box commands with per-box taking precedence

Example output:
```
boxes: running
  Name: boxes
  DNS: ec2-44-243-101-4.us-west-2.compute.amazonaws.com
  IP: 44.243.101.4
  Commands:
    ssh - SSH into box
    vnc - Connect via VNC
    rdp - Connect via RDP
```