### PR TITLE
feat: add delete command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { list } from "./commands/list";
 import { run } from "./commands/run";
 import { start } from "./commands/start";
 import { stop } from "./commands/stop";
+import { deleteBox } from "./commands/delete";
 
 import theme from "./theme";
 import { TerminatingWarning } from "./lib/errors";
@@ -231,6 +232,31 @@ To accept charges, re-run with the '--yes' parameter.`,
       console.log(
         `  ${theme.boxId(boxId)} (${instanceId}): imported successfully`,
       );
+    });
+
+  program
+    .command("delete")
+    .description("Delete a box, its instance, and associated snapshots")
+    .argument("<boxId>", 'id of the box, e.g: "steambox"')
+    .option("-y, --yes", "confirm deletion", false)
+    .action(async (boxId, options) => {
+      //  Demand confirmation - this is a destructive operation.
+      await assertConfirmation(
+        options,
+        "yes",
+        `This will permanently delete the box '${boxId}', terminate its EC2 instance, and delete associated snapshots.
+This action cannot be undone. To confirm, re-run with the '--yes' parameter.`,
+      );
+
+      const { instanceId, deletedSnapshots } = await deleteBox({ boxId });
+      console.log(
+        `  ${theme.boxId(boxId)} (${instanceId}): deleted successfully`,
+      );
+      if (deletedSnapshots.length > 0) {
+        console.log(
+          `  Deleted ${deletedSnapshots.length} associated snapshot(s)`,
+        );
+      }
     });
 };
 

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,0 +1,91 @@
+import dbg from "debug";
+import {
+  EC2Client,
+  TerminateInstancesCommand,
+  DescribeSnapshotsCommand,
+  DeleteSnapshotCommand,
+  DescribeInstancesCommand,
+} from "@aws-sdk/client-ec2";
+import { TerminatingWarning } from "../lib/errors";
+import { getBoxes } from "../lib/get-boxes";
+import { getConfiguration } from "../lib/configuration";
+import { tagNames } from "../lib/constants";
+import * as aws from "../lib/aws-helpers";
+
+const debug = dbg("boxes:delete");
+
+export type DeleteOptions = {
+  boxId: string;
+};
+
+export type DeleteResult = {
+  boxId: string;
+  instanceId: string;
+  deletedSnapshots: string[];
+};
+
+export async function deleteBox(options: DeleteOptions): Promise<DeleteResult> {
+  const { boxId } = options;
+
+  //  Get the box, fail with a warning if it is not found.
+  const boxes = await getBoxes();
+  const box = boxes.find((b) => b.boxId === boxId);
+  if (!box) {
+    throw new TerminatingWarning(`Unable to find box with id '${boxId}'`);
+  }
+
+  //  If the box has no instance id, fail.
+  if (!box.instanceId) {
+    throw new TerminatingWarning(
+      `Box with id '${boxId}' has no associated AWS instance ID`,
+    );
+  }
+
+  //  Create an EC2 client.
+  const { aws: awsConfig } = await getConfiguration();
+  const client = new EC2Client({ ...awsConfig });
+
+  //  First, find any snapshots tagged with this box id.
+  debug(`searching for snapshots tagged with ${tagNames.boxId}=${boxId}...`);
+  const snapshotsResponse = await client.send(
+    new DescribeSnapshotsCommand({
+      Filters: [
+        {
+          Name: `tag:${tagNames.boxId}`,
+          Values: [boxId],
+        },
+      ],
+    }),
+  );
+  const snapshots = snapshotsResponse.Snapshots || [];
+  debug(`found ${snapshots.length} snapshot(s) to delete`);
+
+  //  Delete each snapshot.
+  const deletedSnapshots: string[] = [];
+  for (const snapshot of snapshots) {
+    if (snapshot.SnapshotId) {
+      debug(`deleting snapshot ${snapshot.SnapshotId}...`);
+      await client.send(
+        new DeleteSnapshotCommand({
+          SnapshotId: snapshot.SnapshotId,
+        }),
+      );
+      deletedSnapshots.push(snapshot.SnapshotId);
+    }
+  }
+
+  //  Now terminate the instance.
+  debug(`terminating instance ${box.instanceId}...`);
+  await client.send(
+    new TerminateInstancesCommand({
+      InstanceIds: [box.instanceId],
+    }),
+  );
+  debug(`instance ${box.instanceId} terminated`);
+
+  return {
+    boxId,
+    instanceId: box.instanceId,
+    deletedSnapshots,
+  };
+}

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -4,13 +4,11 @@ import {
   TerminateInstancesCommand,
   DescribeSnapshotsCommand,
   DeleteSnapshotCommand,
-  DescribeInstancesCommand,
 } from "@aws-sdk/client-ec2";
 import { TerminatingWarning } from "../lib/errors";
 import { getBoxes } from "../lib/get-boxes";
 import { getConfiguration } from "../lib/configuration";
 import { tagNames } from "../lib/constants";
-import * as aws from "../lib/aws-helpers";
 
 const debug = dbg("boxes:delete");
 


### PR DESCRIPTION
## Summary
- Add `boxes delete <boxId>` command to permanently remove a box
- Terminates EC2 instance and deletes associated volume snapshots
- Requires `--yes` flag to confirm deletion